### PR TITLE
fix for iPad air, ignores hw manufacturer

### DIFF
--- a/TPAACAudioConverter.m
+++ b/TPAACAudioConverter.m
@@ -69,7 +69,7 @@ static inline BOOL _checkResultLite(OSStatus result, const char *operation, cons
     }
     
     for (UInt32 i=0; i < numEncoders; ++i) {
-        if ( encoderDescriptions[i].mSubType == kAudioFormatMPEG4AAC && encoderDescriptions[i].mManufacturer == kAppleHardwareAudioCodecManufacturer ) {
+        if ( encoderDescriptions[i].mSubType == kAudioFormatMPEG4AAC  ) {
             available_set = YES;
             available = YES;
             return YES;


### PR DESCRIPTION
iPad air's mManufacturer doesn't match kAppleHardwareAudioCodecManufacturer, and the function fails. 

The change skips a the hw accelerated codec check, and rely's on any MPEG4AAC encoder available.
